### PR TITLE
Two CLI improvements

### DIFF
--- a/lib/churn/cli.ex
+++ b/lib/churn/cli.ex
@@ -4,7 +4,7 @@ defmodule Churn.CLI do
   """
 
   @strict_requirements [
-    min_score_to_show: :integer,
+    min_score_to_show: :float,
     commit_since: :string,
     directories_to_scan: :string,
     file_extensions: :string,

--- a/lib/churn/configuration.ex
+++ b/lib/churn/configuration.ex
@@ -9,7 +9,7 @@ defmodule Churn.Configuration do
   use TypedStruct
 
   typedstruct enforce: true do
-    field(:min_score_to_show, pos_integer())
+    field(:min_score_to_show, float())
     field(:commit_since, String.t())
     field(:output_type, :console)
     field(:directories_to_scan, [String.t()])

--- a/lib/churn/renderer/console.ex
+++ b/lib/churn/renderer/console.ex
@@ -13,7 +13,16 @@ defmodule Churn.Renderer.Console do
     |> Enum.map(fn result ->
       [result.file.path, result.times_changed, result.complexity, result.score]
     end)
-    |> TableRex.quick_render!(header, @title)
+    |> do_render(header, @title)
+  end
+
+  defp do_render([] = _results, _header, _title) do
+    IO.puts "(No results. Please try again with different options.)"
+  end
+
+  defp do_render(results, header, title) do
+    results
+    |> TableRex.quick_render!(header, title)
     |> IO.puts()
   end
 end


### PR DESCRIPTION
I ran this on a project and the worst module scored less than 1.

I tried filtering with `-s "0.3"` but it had no effect. I tried filtering with `-s "3"` and it raised an error because there were no rows to render.

This PR fixes both problems:

- `-s "0.3"` works
- If no rows are found, it prints a helpful message